### PR TITLE
Bringing org.clojure/core.match dependency from version 0.2.2 to 1.0.…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Clojure finite state machines"
   :dependencies [[org.clojure/clojure "1.7.0"]
 		 [dorothy "0.0.6"]
-                 [org.clojure/core.match "0.2.2"]]
+                 [org.clojure/core.match "1.0.0"]]
   :dev-dependencies [[server-socket "1.0.0"] ;; used for examples/simple_server.clj		     
 		     [org.clojars.weavejester/autodoc "0.9.0"]]
   :autodoc {:web-src-dir "https://github.com/cdorrat/reduce-fsm/"


### PR DESCRIPTION
Before:
```bash
$ grep core.match project.clj 
                 [org.clojure/core.match "0.2.2"]]
$ lein art
WARNING: boolean? already refers to: #'clojure.core/boolean? in namespace: clojure.tools.analyzer.utils, being replaced by: #'clojure.tools.analyzer.utils/boolean?
WARNING: boolean? already refers to: #'clojure.core/boolean? in namespace: clojure.tools.analyzer, being replaced by: #'clojure.tools.analyzer.utils/boolean?
Rendering ART target/cljs/resources/fluffy-clouds
```

After:
```bash
$ grep core.match project.clj 
                 [org.clojure/core.match "1.0.0"]]
$ lein art
Rendering ART target/cljs/resources/fluffy-clouds
```

よろしくお願い致します!