### PR TITLE
Update project.clj to fix overload warnings at tools analzyer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject reduce-fsm "0.1.4"
   :description "Clojure finite state machines"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.12.0"]
 		 [dorothy "0.0.6"]
-                 [org.clojure/core.match "0.2.2"]]
+                 [org.clojure/core.match "1.1.0"]]
   :dev-dependencies [[server-socket "1.0.0"] ;; used for examples/simple_server.clj		     
 		     [org.clojars.weavejester/autodoc "0.9.0"]]
   :autodoc {:web-src-dir "https://github.com/cdorrat/reduce-fsm/"


### PR DESCRIPTION
(core.match dependency)